### PR TITLE
task 3

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,11 +1,19 @@
 terraform {
+  required_version = ">= 0.13"
+}
+terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = ">=0.13"
     }
+    template = { 
+      source =  "hashicorp/template"
+      version = ">= 2.1"}
   }
-  required_version = ">=1.5"
+ # required_version = ">=0.13"
 }
+
 terraform {
 backend "s3" {
 endpoint = "storage.yandexcloud.net"

--- a/variables.tf
+++ b/variables.tf
@@ -14,7 +14,7 @@ variable "default_zone" {
   default     = "ru-central1-a"
   description = "https://cloud.yandex.ru/docs/overview/concepts/geo-scope"
 }
-variable "default_cidr" {
+/*variable "default_cidr" {
   type        = list(string)
   default     = ["10.0.1.0/24"]
   description = "https://cloud.yandex.ru/docs/vpc/operations/subnet-create"
@@ -41,12 +41,13 @@ variable "vm_db_name" {
   type        = string
   default     = "netology-develop-platform-db"
   description = "example vm_db_ prefix"
-}
+}*/
 variable "ssh_public_key" {
   type    = string
   default = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICQHGZDYpyd9mjTq69K8bZrI5gbHOofvAjTit8Td1ex8 user@study"
  }
 variable "test_vm" {
+  type = map
   default = { 
   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main",
   env_name       = "develop",
@@ -59,6 +60,7 @@ variable "test_vm" {
   }
 }
 variable "example_vm" {
+  type = map
   default = { 
   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main",
   env_name       = "stage",


### PR DESCRIPTION
user@study:~/home_work/ter-homeworks/ter-homeworks-05$ docker run --rm -v $(pwd):/data -t ghcr.io/terraform-linters/tflint
2 issue(s) found:

Warning: Module source "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main" uses a default branch as ref (main) (terraform_module_pinned_source)

  on main.tf line 22:
  22:   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.5.0/docs/rules/terraform_module_pinned_source.md

Warning: Module source "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main" uses a default branch as ref (main) (terraform_module_pinned_source)

  on main.tf line 44:
  44:   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.5.0/docs/rules/terraform_module_pinned_source.md

user@study:~/home_work/ter-homeworks/ter-homeworks-05$ 
Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
        FAILED for resource: example-vm
        File: /main.tf:40-61
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-git-url-with-commit-hash-revision

                40 | module "example-vm" {
                41 |   labels = {
                42 |     label = "analytics"
                43 |   }
                44 |   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
                45 |   env_name       = var.example_vm.env_name
                46 |   #network_id     = yandex_vpc_network.develop.id
                47 |   network_id = module.vpc.vpc_network.id
                48 |   subnet_zones   = [var.example_vm.subnet_zones]
                49 |   #subnet_ids     = [yandex_vpc_subnet.develop.id]
                50 |   subnet_ids     = [module.vpc.vpc_subnet.id]
                51 |   instance_name  = var.example_vm.instance_name
                52 |   instance_count = var.example_vm.instance_count
                53 |   image_family   = var.example_vm.image_family
                54 |   public_ip      = var.example_vm.public_ip
                55 | 
                56 |     metadata = {
                57 |     user-data          = data.template_file.cloudinit.rendered 
                58 |     serial-port-enable = var.example_vm.serial-port-enable
                59 |   }
                60 |  
                61 | }

```
user@study:~/home_work/ter-homeworks/ter-homeworks-05$ terraform plan
Acquiring state lock. This may take a few moments...
module.test-vm.data.yandex_compute_image.my_image: Reading...
data.template_file.cloudinit: Reading...
module.example-vm.data.yandex_compute_image.my_image: Reading...
data.template_file.cloudinit: Read complete after 0s [id=0e4eef7ccc45c95b0fd066bfa8768e55f718d51e123c0528a8a2509f0a674271]
module.test-vm.data.yandex_compute_image.my_image: Read complete after 9s [id=fd8kp2cfs7pc786lfv2t]
module.example-vm.data.yandex_compute_image.my_image: Read complete after 9s [id=fd8kp2cfs7pc786lfv2t]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.example-vm.yandex_compute_instance.vm[0] will be created
  + resource "yandex_compute_instance" "vm" {
      + allow_stopping_for_update = true
      + created_at                = (known after apply)
      + description               = "TODO: description; {{terraform managed}}"
      + folder_id                 = (known after apply)
      + fqdn                      = (known after apply)
      + gpu_cluster_id            = (known after apply)
      + hostname                  = "stage-web-stage-0"
      + id                        = (known after apply)
      + labels                    = {
          + "label" = "analytics"
        }
      + maintenance_grace_period  = (known after apply)
      + maintenance_policy        = (known after apply)
      + metadata                  = {
          + "serial-port-enable" = "1"
          + "user-data"          = <<-EOT
                #cloud-config
                users:
                  - name: ubuntu
                    groups: sudo
                    shell: /bin/bash
                    sudo: ['ALL=(ALL) NOPASSWD:ALL']
                    ssh_authorized_keys:
                      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICQHGZDYpyd9mjTq69K8bZrI5gbHOofvAjTit8Td1ex8 user@study
                
                package_update: true
                package_upgrade: false
                packages:
                 - vim
                 - nginx
            EOT
        }
      + name                      = "stage-web-stage-0"
      + network_acceleration_type = "standard"
      + platform_id               = "standard-v1"
      + service_account_id        = (known after apply)
      + status                    = (known after apply)
      + zone                      = "ru-central1-a"

      + boot_disk {
          + auto_delete = true
          + device_name = (known after apply)
          + disk_id     = (known after apply)
          + mode        = (known after apply)

          + initialize_params {
              + block_size  = (known after apply)
              + description = (known after apply)
              + image_id    = "fd8kp2cfs7pc786lfv2t"
              + name        = (known after apply)
              + size        = 10
              + snapshot_id = (known after apply)
              + type        = "network-hdd"
            }
        }

      + network_interface {
          + index              = (known after apply)
          + ip_address         = (known after apply)
          + ipv4               = true
          + ipv6               = (known after apply)
          + ipv6_address       = (known after apply)
          + mac_address        = (known after apply)
          + nat                = true
          + nat_ip_address     = (known after apply)
          + nat_ip_version     = (known after apply)
          + security_group_ids = (known after apply)
          + subnet_id          = (known after apply)
        }

      + resources {
          + core_fraction = 5
          + cores         = 2
          + memory        = 1
        }

      + scheduling_policy {
          + preemptible = true
        }
    }

  # module.test-vm.yandex_compute_instance.vm[0] will be created
  + resource "yandex_compute_instance" "vm" {
      + allow_stopping_for_update = true
      + created_at                = (known after apply)
      + description               = "TODO: description; {{terraform managed}}"
      + folder_id                 = (known after apply)
      + fqdn                      = (known after apply)
      + gpu_cluster_id            = (known after apply)
      + hostname                  = "develop-web-0"
      + id                        = (known after apply)
      + labels                    = {
          + "label" = "marketing"
        }
      + maintenance_grace_period  = (known after apply)
      + maintenance_policy        = (known after apply)
      + metadata                  = {
          + "serial-port-enable" = "1"
          + "user-data"          = <<-EOT
                #cloud-config
                users:
                  - name: ubuntu
                    groups: sudo
                    shell: /bin/bash
                    sudo: ['ALL=(ALL) NOPASSWD:ALL']
                    ssh_authorized_keys:
                      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICQHGZDYpyd9mjTq69K8bZrI5gbHOofvAjTit8Td1ex8 user@study
                
                package_update: true
                package_upgrade: false
                packages:
                 - vim
                 - nginx
            EOT
        }
      + name                      = "develop-web-0"
      + network_acceleration_type = "standard"
      + platform_id               = "standard-v1"
      + service_account_id        = (known after apply)
      + status                    = (known after apply)
      + zone                      = "ru-central1-a"

      + boot_disk {
          + auto_delete = true
          + device_name = (known after apply)
          + disk_id     = (known after apply)
          + mode        = (known after apply)

          + initialize_params {
              + block_size  = (known after apply)
              + description = (known after apply)
              + image_id    = "fd8kp2cfs7pc786lfv2t"
              + name        = (known after apply)
              + size        = 10
              + snapshot_id = (known after apply)
              + type        = "network-hdd"
            }
        }

      + network_interface {
          + index              = (known after apply)
          + ip_address         = (known after apply)
          + ipv4               = true
          + ipv6               = (known after apply)
          + ipv6_address       = (known after apply)
          + mac_address        = (known after apply)
          + nat                = true
          + nat_ip_address     = (known after apply)
          + nat_ip_version     = (known after apply)
          + security_group_ids = (known after apply)
          + subnet_id          = (known after apply)
        }

      + resources {
          + core_fraction = 5
          + cores         = 2
          + memory        = 1
        }

      + scheduling_policy {
          + preemptible = true
        }
    }

  # module.vpc.yandex_vpc_network.network will be created
  + resource "yandex_vpc_network" "network" {
      + created_at                = (known after apply)
      + default_security_group_id = (known after apply)
      + folder_id                 = (known after apply)
      + id                        = (known after apply)
      + labels                    = (known after apply)
      + name                      = "develop"
      + subnet_ids                = (known after apply)
    }

  # module.vpc.yandex_vpc_subnet.subnet will be created
  + resource "yandex_vpc_subnet" "subnet" {
      + created_at     = (known after apply)
      + folder_id      = (known after apply)
      + id             = (known after apply)
      + labels         = (known after apply)
      + name           = "develop-ru-central1-a"
      + network_id     = (known after apply)
      + v4_cidr_blocks = [
          + "10.0.1.0/24",
        ]
      + v6_cidr_blocks = (known after apply)
      + zone           = "ru-central1-a"
    }

Plan: 4 to add, 0 to change, 0 to destroy.
```
